### PR TITLE
Fan out tests across python/django versions using tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,37 @@
 language: python
+python:
+    - 2.7
+    - 3.3
+    - 3.4
+    - 3.5
+    - 3.6
+
+cache: pip
+
+env:
+    - TOXENV=django18
+    - TOXENV=django110
+    - TOXENV=django111
+
+matrix:
+    exclude:
+    - python: 3.6
+      env: TOXENV=django18
+    - python: 3.3
+      env: TOXENV=django110
+    - python: 3.6
+      env: TOXENV=django110
+    - python: 3.3
+      env: TOXENV=django111
+    include:
+    - python: 3.6
+      env: TOXENV=quality
 
 install:
-    - pip install -r requirements/base.txt
     - pip install -r requirements/test.txt
 
-script:
-    - pylint django_mysql_retry_init
-    - pycodestyle django_mysql_retry_init
-    - echo "import django_mysql_retry_init" > meow.py
-    - coverage run --source=django_mysql_retry_init --branch meow.py
-
-after_success:
-    coveralls
+script: tox
+after_success: coveralls
 
 notifications:
       email: false

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ django application using MySQL.
 
 This is for startup only, I make no attempt at dealing with lost
 connections during operation.
+
+## Django version support
+I've targeted (and test against) each django/python version pair that
+is listed [on djangoproject.com](https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django), with the exception of 1.9 which
+is [unsupported](https://www.djangoproject.com/download/#supported-versions).
+
+| Django Version | Python Version(s)  |
+|----------------|--------------------|
+|       1.8      | 2.7, 3.3, 3.4, 3.5 |
+|      1.10      | 2.7, 3.4, 3.5      |
+|      1.11      | 2.7, 3.4, 3.5, 3.6 |

--- a/meow.py
+++ b/meow.py
@@ -1,0 +1,2 @@
+#/user/bin/python
+import django_mysql_retry_init

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 coveralls==1.1
 pycodestyle==2.3.1
 pylint==1.7.2
+tox==2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = {py27,py33,py34,py35}-django18,{py27,py34,py35}-django110,{py27,py34,py35,py36}-django111
+skipsdist = True
+
+[testenv]
+deps =
+    -r{toxinidir}/requirements/test.txt
+    django18: django>=1.8,<1.9
+    django110: django>=1.10,<1.11
+    django111: django>=1.11
+    quality: django>=1.8
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+commands=
+    coverage run --source=django_mysql_retry_init --branch meow.py
+
+[testenv:quality]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+commands=
+    pylint django_mysql_retry_init
+    pycodestyle django_mysql_retry_init


### PR DESCRIPTION
Addresses https://github.com/efischer19/django_mysql_retry_init/issues/5

I used https://www.djangoproject.com/download/ and https://docs.djangoproject.com/en/1.11/faq/install/ to determine which versions to test.